### PR TITLE
Update code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,7 +10,7 @@ These guidelines aim to support a community where all people should feel safe to
 These guidelines outline our behavior expectations as members of the MNE-Tools community in all MNE-related activities, both offline and online. Your participation is contingent upon following these guidelines in all MNE-related activities, including but not limited to:
 
 - Participating in MNE-Tools code repositories (opening, reviewing, or commenting on issues or pull requests).
-- Participating in MNE-related forums, mailing lists, wikis, websites, chat channels, bugs, group or person-to-person meetings, and related correspondence.
+- Participating in MNE-related forums, mailing lists, wikis, websites, chat channels, group or person-to-person meetings, and related correspondence.
 - Working with other MNE-Tools contributors and community participants virtually or co-located.
 - Participating in MNE-Tools training events.
 - Representing MNE-Tools at public events or in social media (official accounts, staff accounts, personal accounts, Facebook pages).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -127,7 +127,7 @@ Everyone is encouraged to ask questions about these guidelines. One way to ask i
 
 ## Modifications to these Guidelines
 
-These guidelines may be amended from time to time. Your agreement to comply with the guidelines will be deemed agreement to any changes to it.
+These guidelines may be amended from time to time. Continued engagement with MNE-Tools projects implies your agreement to the current state of these guidelines in force at the time.
 Changes to these guidelines are logged [here](https://github.com/mne-tools/.github/commits/main/CODE_OF_CONDUCT.md).
 
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,46 +1,137 @@
-# Contributor Covenant Code of Conduct
+# MNE-Tools Community Participation Guidelines
 
-## Our Pledge
+As a worldwide community of working neuroscientists and neuroscience enthusiasts, we do our best to recognize, appreciate and respect the diversity of our contributors. The MNE-Tools projects welcome contributions from everyone who shares our goals and wants to contribute in a healthy and constructive manner within our community. As such, we have adopted this code of conduct and require all those who participate to agree and adhere to these Community Participation Guidelines in order to help us create a safe and positive community experience for all.
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+These guidelines aim to support a community where all people should feel safe to participate, introduce new ideas and inspire others. In the interest of fostering an open and welcoming environment, **we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of national origin, geographic location, native language, race and ethnicity, caste, social class, socioeconomic status, religion, family and marital status, gender identity and expression, sex, sexual orientation, age, ability, appearance, education, level of experience, or any other dimension of diversity.** We gain strength from diversity and actively seek participation from those who enhance it. These guidelines exist to enable diverse individuals and groups to interact and collaborate to mutual advantage. This document outlines both expected and prohibited behavior. 
 
-## Our Standards
 
-Examples of behavior that contributes to creating a positive environment include:
+## When and How to Use These Guidelines
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+These guidelines outline our behavior expectations as members of the MNE-Tools community in all MNE-related activities, both offline and online. Your participation is contingent upon following these guidelines in all MNE-related activities, including but not limited to:
 
-Examples of unacceptable behavior by participants include:
+- Participating in MNE-Tools code repositories (opening, reviewing, or commenting on issues or pull requests).
+- Participating in MNE-related forums, mailing lists, wikis, websites, chat channels, bugs, group or person-to-person meetings, and related correspondence.
+- Working with other MNE-Tools contributors and community participants virtually or co-located.
+- Participating in MNE-Tools training events.
+- Representing MNE-Tools at public events or in social media (official accounts, staff accounts, personal accounts, Facebook pages).
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+While these guidelines / code of conduct are specifically aimed at the MNE-Tools community, we recognize that it is possible for actions taken outside of our online or in person spaces to have a deep impact on community health. (For example, actions taken outside of MNE-Tools spaces that target our members may be considered grounds for removal from MNE-Tools spaces.) This is an active topic in the diversity and inclusion realm. We anticipate wide-ranging discussions among our communities about appropriate boundaries.
 
-## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+## Expected Behavior
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+The following behaviors are expected of all members of our community:
 
-## Scope
+### Show Respect, Kindness, and Empathy
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+Value each other’s opinions, ideas, styles and viewpoints. We may not always agree, but disagreement is no excuse for poor manners. Be open to different possibilities and to being wrong. Be respectful in all interactions and communications, especially when debating the merits of different options. Be aware of your impact and how intense interactions may be affecting people. Be direct, constructive and positive. Take responsibility for your impact and your mistakes — if someone says they have been harmed through your words or actions, listen carefully, apologize sincerely, and correct the behavior going forward.
 
-## Enforcement
+### Be Direct but Professional
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at mne-conduct@googlegroups.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Give feedback that is constructive, and gracefully accept such feedback. We are likely to have some discussions about if and when criticism is respectful and when it’s not. We must be able to speak directly when we disagree and when we think we need to improve. We cannot withhold hard truths. Doing so respectfully is hard, doing so when others don’t seem to be listening is harder, and hearing such comments when one is the recipient can be even harder still. We need to be honest and direct, as well as respectful.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+### Be Inclusive
+
+Seek diverse perspectives. Diversity of views and of people on teams powers innovation, even if it is not always comfortable. Encourage all voices. Help new perspectives be heard and listen actively. If you find yourself dominating a discussion, it is especially important to step back and encourage other voices to join in, and listen actively to them. Be aware of how much time is taken up by dominant members of the group. Think about how you can provide alternative ways to contribute or participate when possible. Be inclusive of everyone in an interaction, respecting and facilitating people’s participation whether they are:
+
+- Remote (on video or phone)
+- Not native language speakers
+- Coming from a different culture
+- Using pronouns other than “he” or “she”
+- Living in a different time zone
+- Facing other challenges to participate
+
+### Appreciate and Accommodate Our Similarities and Differences
+
+Our contributors come from many cultures and backgrounds. Cultural differences can encompass everything from official religious observances to personal habits to clothing. Be respectful of people with different cultural practices, attitudes and beliefs. Work to eliminate your own biases, prejudices and discriminatory practices. Think of others’ needs from their point of view. Use preferred titles (including pronouns) and the appropriate tone of voice. Respect people’s right to privacy and confidentiality. It is unrealistic to expect our members to know the cultural practices of every ethnic and cultural group, so be open to learning from and educating others as well as educating yourself.
+
+### Lead by Example
+
+Strive to be an example for inclusive thinking, and hold yourself and others accountable for inclusive behaviors. By matching your actions with your words, you become a person others want to follow. Your actions influence others to behave and respond in ways that are valuable and appropriate for our organizational outcomes. Help design our community and our work for inclusion. Make decisions based on what is best not just for us as individuals, but for the overall community. Our goal should not be to “win” every disagreement or argument. A more productive goal is to be open to ideas that make our own ideas better. “Winning” is when different perspectives make our work richer and stronger.
+
+
+## Behavior That Will Not Be Tolerated
+
+The following behaviors are considered to be unacceptable under these guidelines.
+
+### Violence and Threats of Violence
+
+Violence and threats of violence are not acceptable, online or offline. This includes incitement of violence toward any individual, including encouraging a person to commit self-harm. This also includes posting or threatening to post other people’s personally identifying information (“doxxing”) online.
+
+### Personal Attacks
+
+Conflicts will inevitably arise, but frustration should never turn into a personal attack. It is not okay to insult, demean or belittle others. Attacking someone for their opinions, beliefs and ideas is not acceptable. It is important to speak directly when we disagree and when we think we need to improve, but such discussions must be conducted respectfully and professionally, remaining focused on the issue at hand.
+
+### Derogatory Language
+
+Hurtful or harmful language related to
+national origin, geographic location, native language, race and ethnicity, caste, social class, socioeconomic status, religion, family and marital status, gender identity and expression, sex, sexual orientation, age, ability, appearance, education, level of experience, or any other dimension of diversity
+is not acceptable. This includes deliberately referring to someone by a gender that they do not identify with, and/or questioning the legitimacy of an individual’s gender identity. If you’re unsure if a word is derogatory, don’t use it. This also includes repeated subtle and/or indirect discrimination; when asked to stop, stop the behavior in question.
+
+### Unwelcome Sexual Attention or Physical Contact
+
+Unwelcome sexual attention or unwelcome physical contact is not acceptable. This includes sexualized comments, jokes or imagery in interactions, communications or presentation materials, as well as inappropriate touching, groping, or sexual advances. Additionally, touching a person without permission, including sensitive areas such as their hair, pregnant stomach, mobility device (wheelchair, scooter, etc) or tattoos is unacceptable. This includes physically blocking or intimidating another person. Physical contact or simulated physical contact (such as emojis like “kiss”) without affirmative consent is not acceptable. The sharing or distribution of sexualized images or text is unacceptable.
+
+### Disruptive Behavior
+
+Sustained disruption of events, forums, or meetings, including talks and presentations, will not be tolerated. This includes:
+
+* ‘Talking over’ or ‘heckling’ speakers.
+* Drinking alcohol to excess or using recreational drugs to excess, or pushing others to do so — physically or through jeering.
+* Making derogatory comments about those who use or abstain from alcohol or other substances, or talking about their abstinence or consumption preferences to others.
+* Otherwise influencing crowd actions that cause hostility in the session.
+
+### Influencing Unacceptable Behavior
+
+We will treat influencing or leading such activities the same way we treat the activities themselves, and thus the same consequences apply.
+
+
+## Consequences of Unacceptable Behavior
+
+Bad behavior from any member of our community, including those with decision-making authority, will not be tolerated. Intentional efforts to exclude people (except as part of a consequence of the guidelines or other official action) from community activities are not acceptable and will be dealt with appropriately.
+
+Reports of harassment/discrimination will be promptly and thoroughly investigated by the people responsible for the safety of the space, event or activity. Appropriate measures will be taken to address the situation.
+
+Anyone being asked to stop unacceptable behavior is expected to comply immediately. Violation of these guidelines can result in anyone being asked to leave an event or online space, either temporarily or for the duration of the event, or being banned from participation in spaces, or future events and activities in perpetuity.
+
+Any community members who abuse the reporting process will be considered to be in violation of these guidelines and subject to the same consequences. False reporting, especially to retaliate or exclude, will not be accepted or tolerated.
+
+
+## Reporting
+
+If you believe you’re experiencing unacceptable behavior that will not be tolerated as outlined above, please use mne-conduct@googlegroups.com to report.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+Please also report to us if you observe a potentially dangerous situation, someone in distress, or violations of these guidelines, even if the situation is not happening to you.
+
+If you feel you have been unfairly accused of violating these guidelines, please follow the same reporting process. 
+
+
+## Enforcement Responsibilities
+
+Reports of violation of these guidelines are triaged by the Community Participation Guidelines Response Leads.
+After receiving a report, they will review and determine the next steps.
+They will involve other colleagues or outside specialists (such as legal counsel), as needed to appropriately address each situation.
+
+Our community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+Our community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to these Guidelines, and will communicate reasons for moderation decisions when appropriate.
+
+
+## Asking Questions
+
+Everyone is encouraged to ask questions about these guidelines. One way to ask is to [open an issue here](https://github.com/mne-tools/.github/issues/new/choose).
+
+
+## Modifications to these Guidelines
+
+These guidelines may be amended from time to time. Your agreement to comply with the guidelines will be deemed agreement to any changes to it.
+Changes to these guidelines are logged [here](https://github.com/mne-tools/.github/commits/main/CODE_OF_CONDUCT.md).
+
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This document is adapted from the [Mozilla Community Participation Guidelines][moz] and the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/][version].
 
 [homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[version]: https://www.contributor-covenant.org/version/2/1/
+[moz]: https://www.mozilla.org/en-US/about/governance/policies/participation/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -110,9 +110,12 @@ If you feel you have been unfairly accused of violating these guidelines, please
 ## Enforcement Responsibilities
 
 Reports of violation of these guidelines are triaged by the Community Participation Guidelines Response Leads.
+Our current "Community Participation Guidelines Response Leads" are listed `here<https://mne.tools/dev/overview/people.html#governance-cpgrl>`__.
 After receiving a report, they will review and determine the next steps.
-They will involve other colleagues or outside specialists (such as legal counsel), as needed to appropriately address each situation.
+They will involve other colleagues or outside specialists (such as legal counsel) as needed to appropriately address each situation.
 
+Our "community leaders" are members of the MNE-Python steering council, plus anyone with commit rights on an MNE-Tools repository.
+Our community leaders will coordinate with the Community Participation Guideline Response Leads as necessary in resolving any reports.
 Our community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 Our community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to these Guidelines, and will communicate reasons for moderation decisions when appropriate.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,7 +15,7 @@ These guidelines outline our behavior expectations as members of the MNE-Tools c
 - Participating in MNE-Tools training events.
 - Representing MNE-Tools at public events or in social media (official accounts, staff accounts, personal accounts, Facebook pages).
 
-While these guidelines / code of conduct are specifically aimed at the MNE-Tools community, we recognize that it is possible for actions taken outside of our online or in person spaces to have a deep impact on community health. (For example, actions taken outside of MNE-Tools spaces that target our members may be considered grounds for removal from MNE-Tools spaces.) This is an active topic in the diversity and inclusion realm. We anticipate wide-ranging discussions among our communities about appropriate boundaries.
+While these guidelines / code of conduct are specifically aimed at the MNE-Tools community, we recognize that it is possible for actions taken outside of our online or in person spaces to have a deep impact on community health. For example, actions taken outside of MNE-Tools spaces that target our members may be considered grounds for removal from MNE-Tools spaces. This is an active topic in the diversity and inclusion realm. We anticipate wide-ranging discussions among our communities about appropriate boundaries.
 
 
 ## Expected Behavior

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -120,6 +120,27 @@ Our community leaders are responsible for clarifying and enforcing our standards
 Our community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to these Guidelines, and will communicate reasons for moderation decisions when appropriate.
 
 
+## Enforcement Guidelines
+
+Community leaders will follow these "Community Impact Guidelines" in determining the consequences for any action they deem in violation of this Code of Conduct. These are listed in order of increasing severity:
+
+1. An incident of language or behavior deemed unprofessional or unwelcome in the community.
+
+   ** Consequence:** *Correction.* A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+2. A violation of these guidelines (see "Behavior that will not be tolerated", above), either as a single incident or a series of actions.
+
+   ** Consequence:** *Warning.* No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+3. A serious violation of these guidelines, including sustained inappropriate behavior.
+
+   ** Consequence:** *Temporary Ban.* A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+4. A pattern of violation of community standards, including sustained inappropriate behavior, repeated harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+   ** Consequence:** *Permanent Ban.* A permanent ban from any sort of public interaction within the community.
+
+
 ## Asking Questions
 
 Everyone is encouraged to ask questions about these guidelines. One way to ask is to [open an issue here](https://github.com/mne-tools/.github/issues/new/choose).

--- a/images/mne_logo_small.svg
+++ b/images/mne_logo_small.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="141pt" height="33.75pt" viewBox="0 0 141 33.75" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2022-04-13T15:28:23.367808</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.5.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="axes_1">
+   <g clip-path="url(#p4b09d73451)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAEIAAAAQCAYAAACiEqkUAAAAsElEQVR4nO2QW2rEMBAEa8Ri2WLXd8rJcyeH+Bnc+VCHwJ5hCoYeNZI+KiR0r4H2gK2gve86Am2BzoC9/HdODp+P0vN0fwa6vDt1FXQG62PuU2fW8cXaZvbpyac++N4ry9b42hrL2ViuxvLT0BDcQ6Ah0IAz0AM0eq++MwaqoNo7jX3u0e+mt37yH61QSABSxB8pwqQIkyJMijApwqQIkyJMijApwqQIkyJMijApwvwCdAFgHcVQk7IAAAAASUVORK5CYII=" id="image580da91bb7" transform="scale(1 -1)translate(0 -12)" x="86" y="-10.75" width="49.5" height="12"/>
+   </g>
+   <g id="patch_1">
+    <path d="M 24.403707 28.911808 
+L 24.403707 16.530814 
+L 19.255463 25.033658 
+Q 19.163356 25.21787 18.945211 25.28089 
+Q 18.727065 25.34391 18.571939 25.34391 
+Q 18.387726 25.34391 18.169581 25.28089 
+Q 17.951435 25.21787 17.859329 25.033658 
+L 12.711085 16.530814 
+L 12.711085 28.911808 
+L 6.409091 28.911808 
+L 6.409091 4.838192 
+L 12.303879 4.838192 
+Q 12.614131 4.838192 12.832277 5.11451 
+L 18.542852 14.640216 
+L 24.282514 5.11451 
+Q 24.50066 4.838192 24.776978 4.838192 
+L 30.7057 4.838192 
+L 30.7057 28.911808 
+L 24.403707 28.911808 
+z
+M 49.381899 28.882722 
+L 41.034181 16.03635 
+L 41.034181 28.882722 
+L 34.610995 28.882722 
+L 34.610995 4.838192 
+L 41.005095 4.838192 
+L 49.381899 17.805756 
+L 49.381899 4.838192 
+L 55.834171 4.838192 
+L 55.834171 28.882722 
+L 49.381899 28.882722 
+z
+M 59.293479 28.911808 
+L 59.293479 4.838192 
+L 78.500016 4.838192 
+L 78.500016 10.577854 
+L 65.561538 10.577854 
+L 65.561538 14.019712 
+L 77.753472 14.019712 
+L 77.753472 19.759374 
+L 65.561538 19.759374 
+L 65.561538 23.201232 
+L 78.500016 23.201232 
+L 78.500016 28.911808 
+L 59.293479 28.911808 
+z
+" clip-path="url(#p4b09d73451)" style="fill: #808080"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p4b09d73451">
+   <rect x="0" y="3.634511" width="141" height="26.480977"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,7 @@
+![MNE logo](https://github.com/mne-tools/.github/blob/main/images/mne_logo_small.svg) 
+
+MNE-tools hosts a collection of software packages for analysis of (human) neuroimaging data, with emphasis on EEG, MEG, ECoG, iEEG, and fNIRS data. Limited support for MRI data is also provided, mostly for defining brain surfaces/volumes used to restrict inverse imaging of external (MEG) or scalp-based (EEG) data.  For more in-depth MRI or fMRI analysis, see http://nipy.org/.
+
+----
+
+Projects hosted by the MNE-tools organization are governed by our [Community Guidelines](https://github.com/mne-tools/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 ![MNE logo](https://github.com/mne-tools/.github/blob/main/images/mne_logo_small.svg) 
 
-MNE-tools hosts a collection of software packages for analysis of (human) neuroimaging data, with emphasis on EEG, MEG, ECoG, iEEG, and fNIRS data. Limited support for MRI data is also provided, mostly for defining brain surfaces/volumes used to restrict inverse imaging of external (MEG) or scalp-based (EEG) data.  For more in-depth MRI or fMRI analysis, see http://nipy.org/.
+MNE-tools hosts a collection of software packages for analysis of (human) neuroimaging data, with emphasis on EEG, MEG, ECoG, iEEG, and fNIRS data. Limited support for MRI data is also provided, mostly for defining brain surfaces/volumes used to restrict inverse imaging of external (MEG) or scalp-based (EEG) data. For more in-depth MRI or fMRI analysis, see http://nipy.org/.
 
 ----
 


### PR DESCRIPTION
This PR does two things:

1. updates our code-of-conduct to frame it as Contributor Guidelines. The text borrows heavily from the Mozilla Contributor Guidelines (linked in the attribution section), while still incorporating much of the previous content drawn from the Contributor Covenant. Text that directly reflected the contributor covenant has been updated to match the most recent version (1.4 -> 2.1), except as mentioned below.

2. adds a `profile/README.md` document that will display at the top of https://github.com/mne-tools/ (and will link to the guidelines). For an example of how this README will look, see https://github.com/microsoft/

One major outstanding question I have is whether we should update the `Enforcement Responsibilities` section to align with the current (v2.1) contributor covenant (in v2.1 of the covenant the section is now called `Enforcement Guidelines`).  That section has changed considerably since v1.4, and now includes four spelled-out levels of actions/consequences for violation of guidelines.  I am as yet unsure whether we want to commit to those specific definitions of violation and the specific consequences that are paired to them.  On one hand, it might simplify the "what should we do in response" question... on the other hand, maybe the right response wasn't foreseen and the document now requires us to respond in a suboptimal way.  Keen to hear others' opinions on this, and also on any other aspect of the proposed changes.

cc @mne-tools/mne-python-steering-committee
cc @mne-tools/mne-bids
cc @mne-tools/mne-icalabel-admins
cc @mne-tools/mne-realtime